### PR TITLE
Do not crash when parsing nil

### DIFF
--- a/lib/ruby_postal/parser.rb
+++ b/lib/ruby_postal/parser.rb
@@ -3,7 +3,7 @@ require 'ruby_postal/cpostal/parser'
 module Postal
     class Parser
         def self.parse_address(address, options={})
-            parse_result = CParser.parse_address address, options
+            parse_result = CParser.parse_address address.to_s, options
             parse_result.map{|s, c| {:label => c, :value => s}}
         end
     end

--- a/test/ruby_postal_parser_test.rb
+++ b/test/ruby_postal_parser_test.rb
@@ -28,4 +28,8 @@ class RubyPostalParserTest < Minitest::Test
 
             })
     end
+
+    def test_parse_nil
+        assert_equal [], Postal::Parser.parse_address(nil)
+    end
 end


### PR DESCRIPTION
### Problem

Right now when you call `parse_address` passing `nil` the Ruby VM segfaults:

```
➜  ruby_postal git:(parse_nil) ✗ rake test
install -c tmp/x86_64-darwin16/expand/2.3.3/expand.bundle lib/ruby_postal/cpostal/expand.bundle
cp tmp/x86_64-darwin16/expand/2.3.3/expand.bundle tmp/x86_64-darwin16/stage/lib/ruby_postal/cpostal/expand.bundle
install -c tmp/x86_64-darwin16/parser/2.3.3/parser.bundle lib/ruby_postal/cpostal/parser.bundle
cp tmp/x86_64-darwin16/parser/2.3.3/parser.bundle tmp/x86_64-darwin16/stage/lib/ruby_postal/cpostal/parser.bundle
RUBY_GC_HEAP_FREE_SLOTS=500000 (default value: 4096)
RUBY_GC_HEAP_INIT_SLOTS=40000 (default value: 10000)
RUBY_GC_MALLOC_LIMIT=1000000000 (default value: 16777216)
Run options: --seed 30969

# Running:

/Users/lucasuyezu/src/github.com/lucasuyezu/ruby_postal/lib/ruby_postal/parser.rb:6: [BUG] Segmentation fault at 0x00000000000009
ruby 2.3.3p222 (2016-11-21 revision 56859) [x86_64-darwin16]

-- Crash Report log information --------------------------------------------
   See Crash Report log file under the one of following:
     * ~/Library/Logs/CrashReporter
     * /Library/Logs/CrashReporter
     * ~/Library/Logs/DiagnosticReports
     * /Library/Logs/DiagnosticReports
   for more details.
Don't forget to include the above Crash Report log file in bug reports.

-- Control frame information -----------------------------------------------
c:0025 p:---- s:0113 e:000112 CFUNC  :parse_address
c:0024 p:0026 s:0108 e:000107 METHOD /Users/lucasuyezu/src/github.com/lucasuyezu/ruby_postal/lib/ruby_postal/parser.rb:6
c:0023 p:0020 s:0102 e:000099 METHOD /Users/lucasuyezu/src/github.com/lucasuyezu/ruby_postal/test/ruby_postal_parser_test.rb:33
c:0022 p:0029 s:0097 e:000096 BLOCK  /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/minitest-5.10.1/lib/minitest/test.rb:105
c:0021 p:0006 s:0095 e:000094 METHOD /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/minitest-5.10.1/lib/minitest/test.rb:202
c:0020 p:0009 s:0091 e:000090 BLOCK  /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/minitest-5.10.1/lib/minitest/test.rb:102
c:0019 p:0020 s:0089 e:000088 METHOD /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/minitest-5.10.1/lib/minitest/test.rb:253
c:0018 p:0009 s:0085 e:000084 BLOCK  /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/minitest-5.10.1/lib/minitest/test.rb:101
c:0017 p:0037 s:0083 E:0006f0 METHOD /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/minitest-5.10.1/lib/minitest.rb:349
c:0016 p:0052 s:0076 E:000658 METHOD /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/minitest-5.10.1/lib/minitest/test.rb:273
c:0015 p:0009 s:0070 E:0005d0 METHOD /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/minitest-5.10.1/lib/minitest/test.rb:100
c:0014 p:0014 s:0067 e:000066 METHOD /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/minitest-5.10.1/lib/minitest.rb:822
c:0013 p:0032 s:0061 e:000059 METHOD /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/minitest-5.10.1/lib/minitest.rb:323
c:0012 p:0014 s:0054 e:000053 BLOCK  /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/minitest-5.10.1/lib/minitest.rb:310 [FINISH]
c:0011 p:---- s:0051 e:000050 CFUNC  :each
c:0010 p:0010 s:0048 e:000047 BLOCK  /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/minitest-5.10.1/lib/minitest.rb:309
c:0009 p:0037 s:0046 E:000490 METHOD /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/minitest-5.10.1/lib/minitest.rb:349
c:0008 p:0035 s:0039 E:0003f8 METHOD /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/minitest-5.10.1/lib/minitest.rb:336
c:0007 p:0131 s:0033 E:000368 METHOD /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/minitest-5.10.1/lib/minitest.rb:308
c:0006 p:0013 s:0025 e:000024 BLOCK  /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/minitest-5.10.1/lib/minitest.rb:158 [FINISH]
c:0005 p:---- s:0022 e:000021 CFUNC  :map
c:0004 p:0046 s:0019 e:000018 METHOD /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/minitest-5.10.1/lib/minitest.rb:158
c:0003 p:0158 s:0011 e:000010 METHOD /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/minitest-5.10.1/lib/minitest.rb:135
c:0002 p:0071 s:0005 E:000538 BLOCK  /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/minitest-5.10.1/lib/minitest.rb:62 [FINISH]
c:0001 p:0000 s:0002 E:0020f0 (none) [FINISH]

-- Ruby level backtrace information ----------------------------------------
/Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/minitest-5.10.1/lib/minitest.rb:62:in `block in autorun'
/Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/minitest-5.10.1/lib/minitest.rb:135:in `run'
/Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/minitest-5.10.1/lib/minitest.rb:158:in `__run'
/Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/minitest-5.10.1/lib/minitest.rb:158:in `map'
/Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/minitest-5.10.1/lib/minitest.rb:158:in `block in __run'
/Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/minitest-5.10.1/lib/minitest.rb:308:in `run'
/Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/minitest-5.10.1/lib/minitest.rb:336:in `with_info_handler'
/Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/minitest-5.10.1/lib/minitest.rb:349:in `on_signal'
/Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/minitest-5.10.1/lib/minitest.rb:309:in `block in run'
/Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/minitest-5.10.1/lib/minitest.rb:309:in `each'
/Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/minitest-5.10.1/lib/minitest.rb:310:in `block (2 levels) in run'
/Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/minitest-5.10.1/lib/minitest.rb:323:in `run_one_method'
/Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/minitest-5.10.1/lib/minitest.rb:822:in `run_one_method'
/Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/minitest-5.10.1/lib/minitest/test.rb:100:in `run'
/Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/minitest-5.10.1/lib/minitest/test.rb:273:in `with_info_handler'
/Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/minitest-5.10.1/lib/minitest.rb:349:in `on_signal'
/Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/minitest-5.10.1/lib/minitest/test.rb:101:in `block in run'
/Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/minitest-5.10.1/lib/minitest/test.rb:253:in `time_it'
/Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/minitest-5.10.1/lib/minitest/test.rb:102:in `block (2 levels) in run'
/Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/minitest-5.10.1/lib/minitest/test.rb:202:in `capture_exceptions'
/Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/minitest-5.10.1/lib/minitest/test.rb:105:in `block (3 levels) in run'
/Users/lucasuyezu/src/github.com/lucasuyezu/ruby_postal/test/ruby_postal_parser_test.rb:33:in `test_parse_nil'
/Users/lucasuyezu/src/github.com/lucasuyezu/ruby_postal/lib/ruby_postal/parser.rb:6:in `parse_address'
/Users/lucasuyezu/src/github.com/lucasuyezu/ruby_postal/lib/ruby_postal/parser.rb:6:in `parse_address'

-- Machine register context ------------------------------------------------
 rax: 0x0000000000000008 rbx: 0x0000000000000008 rcx: 0x0000000000000008
 rdx: 0x0000000000000000 rdi: 0x0000000000000008 rsi: 0x00007fbda8447f90
 rbp: 0x00007fff519de850 rsp: 0x00007fff519de810  r8: 0x0000000000002f62
  r9: 0x000000010f498f6c r10: 0x0000000000000006 r11: 0x77da9163053cba8d
 r12: 0x00007fbda8406700 r13: 0x00007fbdad2af6c0 r14: 0x0000000000000008
 r15: 0x0000000000000008 rip: 0x000000010f498c8a rfl: 0x0000000000010206

-- C level backtrace information -------------------------------------------
0   ruby                                0x000000010e3c7d04 rb_vm_bugreport + 388
1   ruby                                0x000000010e263b1a rb_bug_context + 490
2   ruby                                0x000000010e3384f4 sigsegv + 68
3   libsystem_platform.dylib            0x00007fffc1572bba _sigtramp + 26
4   parser.bundle                       0x000000010f498c8a rb_parse_address + 298
5   ruby                                0x000000010e3bdf4a vm_call_cfunc + 314
6   ruby                                0x000000010e3a871f vm_exec_core + 10175
7   ruby                                0x000000010e3b878a vm_exec + 122
8   ruby                                0x000000010e3b3e07 rb_yield + 183
9   ruby                                0x000000010e222589 rb_ary_each + 41
10  ruby                                0x000000010e3bdf4a vm_call_cfunc + 314
11  ruby                                0x000000010e3a853d vm_exec_core + 9693
12  ruby                                0x000000010e3b878a vm_exec + 122
13  ruby                                0x000000010e3b3e07 rb_yield + 183
14  ruby                                0x000000010e22800a rb_ary_collect + 442
15  ruby                                0x000000010e3bdf4a vm_call_cfunc + 314
16  ruby                                0x000000010e3a853d vm_exec_core + 9693
17  ruby                                0x000000010e3b878a vm_exec + 122
18  ruby                                0x000000010e3b70a4 vm_invoke_proc + 196
19  ruby                                0x000000010e271d81 rb_proc_call + 81
20  ruby                                0x000000010e26bbc7 rb_exec_end_proc + 359
21  ruby                                0x000000010e26c110 ruby_finalize_0 + 112
22  ruby                                0x000000010e26c26b ruby_cleanup + 331
23  ruby                                0x000000010e26c54d ruby_run_node + 61
24  ruby                                0x000000010e21faef main + 79

-- Other runtime information -----------------------------------------------

* Loaded script: /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rake-12.0.0/lib/rake/rake_test_loader.rb

* Loaded features:

    0 enumerator.so
    1 thread.rb
    2 rational.so
    3 complex.so
    4 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/2.3.0/x86_64-darwin16/enc/encdb.bundle
    5 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/2.3.0/x86_64-darwin16/enc/trans/transdb.bundle
    6 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/2.3.0/unicode_normalize.rb
    7 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/2.3.0/x86_64-darwin16/rbconfig.rb
    8 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/site_ruby/2.3.0/rubygems/compatibility.rb
    9 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/site_ruby/2.3.0/rubygems/defaults.rb
   10 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/site_ruby/2.3.0/rubygems/deprecate.rb
   11 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/site_ruby/2.3.0/rubygems/errors.rb
   12 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/site_ruby/2.3.0/rubygems/version.rb
   13 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/site_ruby/2.3.0/rubygems/requirement.rb
   14 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/site_ruby/2.3.0/rubygems/platform.rb
   15 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/site_ruby/2.3.0/rubygems/basic_specification.rb
   16 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/site_ruby/2.3.0/rubygems/stub_specification.rb
   17 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/site_ruby/2.3.0/rubygems/util/list.rb
   18 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/2.3.0/x86_64-darwin16/stringio.bundle
   19 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/site_ruby/2.3.0/rubygems/specification.rb
   20 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/site_ruby/2.3.0/rubygems/exceptions.rb
   21 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/site_ruby/2.3.0/rubygems/dependency.rb
   22 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/site_ruby/2.3.0/rubygems/core_ext/kernel_gem.rb
   23 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/2.3.0/monitor.rb
   24 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/site_ruby/2.3.0/rubygems/core_ext/kernel_require.rb
   25 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/site_ruby/2.3.0/rubygems.rb
   26 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/site_ruby/2.3.0/rubygems/path_support.rb
   27 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/did_you_mean-1.0.0/lib/did_you_mean/version.rb
   28 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/did_you_mean-1.0.0/lib/did_you_mean/core_ext/name_error.rb
   29 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/did_you_mean-1.0.0/lib/did_you_mean/levenshtein.rb
   30 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/did_you_mean-1.0.0/lib/did_you_mean/jaro_winkler.rb
   31 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/did_you_mean-1.0.0/lib/did_you_mean/spell_checkable.rb
   32 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/2.3.0/delegate.rb
   33 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/did_you_mean-1.0.0/lib/did_you_mean/spell_checkers/name_error_checkers/class_name_checker.rb
   34 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/did_you_mean-1.0.0/lib/did_you_mean/spell_checkers/name_error_checkers/variable_name_checker.rb
   35 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/did_you_mean-1.0.0/lib/did_you_mean/spell_checkers/name_error_checkers.rb
   36 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/did_you_mean-1.0.0/lib/did_you_mean/spell_checkers/method_name_checker.rb
   37 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/did_you_mean-1.0.0/lib/did_you_mean/spell_checkers/null_checker.rb
   38 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/did_you_mean-1.0.0/lib/did_you_mean/formatter.rb
   39 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/did_you_mean-1.0.0/lib/did_you_mean.rb
   40 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/bundler-1.13.6/lib/bundler/postit_trampoline.rb
   41 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/2.3.0/x86_64-darwin16/pathname.bundle
   42 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/2.3.0/pathname.rb
   43 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/bundler-1.13.6/lib/bundler/constants.rb
   44 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/site_ruby/2.3.0/rubygems/util.rb
   45 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/2.3.0/x86_64-darwin16/io/console.bundle
   46 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/site_ruby/2.3.0/rubygems/user_interaction.rb
   47 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/2.3.0/x86_64-darwin16/etc.bundle
   48 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/site_ruby/2.3.0/rubygems/config_file.rb
   49 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/bundler-1.13.6/lib/bundler/rubygems_integration.rb
   50 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/bundler-1.13.6/lib/bundler/current_ruby.rb
   51 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/bundler-1.13.6/lib/bundler/shared_helpers.rb
   52 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/2.3.0/fileutils.rb
   53 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/bundler-1.13.6/lib/bundler/errors.rb
   54 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/bundler-1.13.6/lib/bundler/environment_preserver.rb
   55 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/2.3.0/x86_64-darwin16/socket.bundle
   56 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/2.3.0/x86_64-darwin16/io/wait.bundle
   57 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/2.3.0/socket.rb
   58 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/2.3.0/timeout.rb
   59 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/2.3.0/net/protocol.rb
   60 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/2.3.0/uri/rfc2396_parser.rb
   61 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/2.3.0/uri/rfc3986_parser.rb
   62 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/2.3.0/uri/common.rb
   63 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/2.3.0/uri/generic.rb
   64 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/2.3.0/uri/ftp.rb
   65 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/2.3.0/uri/http.rb
   66 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/2.3.0/uri/https.rb
   67 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/2.3.0/uri/ldap.rb
   68 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/2.3.0/uri/ldaps.rb
   69 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/2.3.0/uri/mailto.rb
   70 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/2.3.0/uri.rb
   71 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/2.3.0/x86_64-darwin16/zlib.bundle
   72 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/2.3.0/net/http/exceptions.rb
   73 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/2.3.0/net/http/header.rb
   74 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/2.3.0/x86_64-darwin16/enc/windows_31j.bundle
   75 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/2.3.0/net/http/generic_request.rb
   76 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/2.3.0/net/http/request.rb
   77 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/2.3.0/net/http/requests.rb
   78 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/2.3.0/net/http/response.rb
   79 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/2.3.0/net/http/responses.rb
   80 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/2.3.0/net/http/proxy_delta.rb
   81 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/2.3.0/net/http/backward.rb
   82 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/2.3.0/net/http.rb
   83 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/2.3.0/x86_64-darwin16/date_core.bundle
   84 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/2.3.0/date.rb
   85 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/2.3.0/time.rb
   86 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/site_ruby/2.3.0/rubygems/request/http_pool.rb
   87 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/site_ruby/2.3.0/rubygems/request/https_pool.rb
   88 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/site_ruby/2.3.0/rubygems/request/connection_pools.rb
   89 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/site_ruby/2.3.0/rubygems/request.rb
   90 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/2.3.0/cgi/core.rb
   91 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/2.3.0/x86_64-darwin16/cgi/escape.bundle
   92 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/2.3.0/cgi/util.rb
   93 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/2.3.0/cgi/cookie.rb
   94 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/2.3.0/cgi.rb
   95 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/site_ruby/2.3.0/rubygems/uri_formatter.rb
   96 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/2.3.0/x86_64-darwin16/digest.bundle
   97 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/2.3.0/digest.rb
   98 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/2.3.0/x86_64-darwin16/openssl.bundle
   99 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/2.3.0/openssl/bn.rb
  100 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/2.3.0/openssl/pkey.rb
  101 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/2.3.0/openssl/cipher.rb
  102 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/2.3.0/openssl/config.rb
  103 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/2.3.0/openssl/digest.rb
  104 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/2.3.0/openssl/x509.rb
  105 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/2.3.0/openssl/buffering.rb
  106 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/2.3.0/x86_64-darwin16/io/nonblock.bundle
  107 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/2.3.0/openssl/ssl.rb
  108 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/2.3.0/openssl.rb
  109 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/2.3.0/securerandom.rb
  110 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/2.3.0/resolv.rb
  111 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/site_ruby/2.3.0/rubygems/remote_fetcher.rb
  112 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/bundler-1.13.6/lib/bundler/gem_remote_fetcher.rb
  113 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/2.3.0/x86_64-darwin16/digest/sha1.bundle
  114 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/bundler-1.13.6/lib/bundler/plugin/api/source.rb
  115 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/bundler-1.13.6/lib/bundler/plugin/api.rb
  116 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/bundler-1.13.6/lib/bundler/plugin.rb
  117 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/site_ruby/2.3.0/rubygems/source/git.rb
  118 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/site_ruby/2.3.0/rubygems/source/installed.rb
  119 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/site_ruby/2.3.0/rubygems/source/specific_file.rb
  120 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/site_ruby/2.3.0/rubygems/source/local.rb
  121 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/site_ruby/2.3.0/rubygems/source/lock.rb
  122 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/site_ruby/2.3.0/rubygems/source/vendor.rb
  123 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/site_ruby/2.3.0/rubygems/source.rb
  124 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/bundler-1.13.6/lib/bundler/gem_helpers.rb
  125 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/bundler-1.13.6/lib/bundler/match_platform.rb
  126 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/bundler-1.13.6/lib/bundler/rubygems_ext.rb
  127 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/bundler-1.13.6/lib/bundler/version.rb
  128 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/bundler-1.13.6/lib/bundler.rb
  129 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/bundler-1.13.6/lib/bundler/settings.rb
  130 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/site_ruby/2.3.0/rubygems/ext/build_error.rb
  131 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/site_ruby/2.3.0/rubygems/ext/builder.rb
  132 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/site_ruby/2.3.0/rubygems/ext/configure_builder.rb
  133 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/2.3.0/tmpdir.rb
  134 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/2.3.0/tempfile.rb
  135 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/site_ruby/2.3.0/rubygems/ext/ext_conf_builder.rb
  136 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/site_ruby/2.3.0/rubygems/ext/rake_builder.rb
  137 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/2.3.0/optparse.rb
  138 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/site_ruby/2.3.0/rubygems/command.rb
  139 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/site_ruby/2.3.0/rubygems/ext/cmake_builder.rb
  140 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/site_ruby/2.3.0/rubygems/ext.rb
  141 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/2.3.0/x86_64-darwin16/strscan.bundle
  142 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/bundler-1.13.6/lib/bundler/source.rb
  143 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/bundler-1.13.6/lib/bundler/source/path.rb
  144 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/bundler-1.13.6/lib/bundler/source/git.rb
  145 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/site_ruby/2.3.0/rubygems/text.rb
  146 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/site_ruby/2.3.0/rubygems/name_tuple.rb
  147 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/site_ruby/2.3.0/rubygems/spec_fetcher.rb
  148 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/bundler-1.13.6/lib/bundler/source/rubygems.rb
  149 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/bundler-1.13.6/lib/bundler/lockfile_parser.rb
  150 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/2.3.0/set.rb
  151 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/bundler-1.13.6/lib/bundler/definition.rb
  152 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/bundler-1.13.6/lib/bundler/dependency.rb
  153 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/bundler-1.13.6/lib/bundler/ruby_dsl.rb
  154 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/bundler-1.13.6/lib/bundler/dsl.rb
  155 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/bundler-1.13.6/lib/bundler/source_list.rb
  156 /Users/lucasuyezu/src/github.com/lucasuyezu/ruby_postal/lib/ruby_postal/version.rb
  157 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/bundler-1.13.6/lib/bundler/index.rb
  158 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/bundler-1.13.6/lib/bundler/source/gemspec.rb
  159 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/bundler-1.13.6/lib/bundler/lazy_specification.rb
  160 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/2.3.0/tsort.rb
  161 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/2.3.0/forwardable.rb
  162 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/bundler-1.13.6/lib/bundler/spec_set.rb
  163 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/bundler-1.13.6/lib/bundler/gem_version_promoter.rb
  164 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/bundler-1.13.6/lib/bundler/runtime.rb
  165 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/bundler-1.13.6/lib/bundler/ui.rb
  166 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/bundler-1.13.6/lib/bundler/ui/silent.rb
  167 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/bundler-1.13.6/lib/bundler/ui/rg_proxy.rb
  168 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/site_ruby/2.3.0/rubygems/util/licenses.rb
  169 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/bundler-1.13.6/lib/bundler/remote_specification.rb
  170 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/bundler-1.13.6/lib/bundler/dep_proxy.rb
  171 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/bundler-1.13.6/lib/bundler/vendor/molinillo/lib/molinillo/gem_metadata.rb
  172 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/bundler-1.13.6/lib/bundler/vendor/molinillo/lib/molinillo/errors.rb
  173 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/bundler-1.13.6/lib/bundler/vendor/molinillo/lib/molinillo/dependency_graph/action.rb
  174 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/bundler-1.13.6/lib/bundler/vendor/molinillo/lib/molinillo/dependency_graph/add_edge_no_circular.rb
  175 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/bundler-1.13.6/lib/bundler/vendor/molinillo/lib/molinillo/dependency_graph/add_vertex.rb
  176 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/bundler-1.13.6/lib/bundler/vendor/molinillo/lib/molinillo/dependency_graph/detach_vertex_named.rb
  177 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/bundler-1.13.6/lib/bundler/vendor/molinillo/lib/molinillo/dependency_graph/set_payload.rb
  178 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/bundler-1.13.6/lib/bundler/vendor/molinillo/lib/molinillo/dependency_graph/tag.rb
  179 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/bundler-1.13.6/lib/bundler/vendor/molinillo/lib/molinillo/dependency_graph/log.rb
  180 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/bundler-1.13.6/lib/bundler/vendor/molinillo/lib/molinillo/dependency_graph/vertex.rb
  181 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/bundler-1.13.6/lib/bundler/vendor/molinillo/lib/molinillo/dependency_graph.rb
  182 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/bundler-1.13.6/lib/bundler/vendor/molinillo/lib/molinillo/state.rb
  183 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/bundler-1.13.6/lib/bundler/vendor/molinillo/lib/molinillo/modules/specification_provider.rb
  184 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/bundler-1.13.6/lib/bundler/vendor/molinillo/lib/molinillo/delegates/resolution_state.rb
  185 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/bundler-1.13.6/lib/bundler/vendor/molinillo/lib/molinillo/delegates/specification_provider.rb
  186 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/bundler-1.13.6/lib/bundler/vendor/molinillo/lib/molinillo/resolution.rb
  187 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/bundler-1.13.6/lib/bundler/vendor/molinillo/lib/molinillo/resolver.rb
  188 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/bundler-1.13.6/lib/bundler/vendor/molinillo/lib/molinillo/modules/ui.rb
  189 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/bundler-1.13.6/lib/bundler/vendor/molinillo/lib/molinillo.rb
  190 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/bundler-1.13.6/lib/bundler/vendored_molinillo.rb
  191 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/bundler-1.13.6/lib/bundler/resolver.rb
  192 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/bundler-1.13.6/lib/bundler/endpoint_specification.rb
  193 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/bundler-1.13.6/lib/bundler/stub_specification.rb
  194 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/bundler-1.13.6/lib/bundler/setup.rb
  195 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rake-12.0.0/lib/rake/version.rb
  196 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/2.3.0/singleton.rb
  197 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/2.3.0/ostruct.rb
  198 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rake-12.0.0/lib/rake/ext/core.rb
  199 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rake-12.0.0/lib/rake/ext/string.rb
  200 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rake-12.0.0/lib/rake/win32.rb
  201 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rake-12.0.0/lib/rake/linked_list.rb
  202 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rake-12.0.0/lib/rake/cpu_counter.rb
  203 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rake-12.0.0/lib/rake/scope.rb
  204 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rake-12.0.0/lib/rake/task_argument_error.rb
  205 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rake-12.0.0/lib/rake/rule_recursion_overflow_error.rb
  206 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rake-12.0.0/lib/rake/task_manager.rb
  207 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rake-12.0.0/lib/rake/cloneable.rb
  208 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rake-12.0.0/lib/rake/file_utils.rb
  209 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rake-12.0.0/lib/rake/file_utils_ext.rb
  210 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rake-12.0.0/lib/rake/file_list.rb
  211 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rake-12.0.0/lib/rake/promise.rb
  212 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rake-12.0.0/lib/rake/thread_pool.rb
  213 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rake-12.0.0/lib/rake/private_reader.rb
  214 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rake-12.0.0/lib/rake/thread_history_display.rb
  215 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rake-12.0.0/lib/rake/trace_output.rb
  216 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rake-12.0.0/lib/rake/application.rb
  217 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rake-12.0.0/lib/rake/rake_module.rb
  218 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rake-12.0.0/lib/rake/pseudo_status.rb
  219 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rake-12.0.0/lib/rake/task_arguments.rb
  220 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rake-12.0.0/lib/rake/invocation_chain.rb
  221 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rake-12.0.0/lib/rake/invocation_exception_mixin.rb
  222 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rake-12.0.0/lib/rake/task.rb
  223 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rake-12.0.0/lib/rake/early_time.rb
  224 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rake-12.0.0/lib/rake/file_task.rb
  225 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rake-12.0.0/lib/rake/file_creation_task.rb
  226 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rake-12.0.0/lib/rake/multi_task.rb
  227 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rake-12.0.0/lib/rake/dsl_definition.rb
  228 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rake-12.0.0/lib/rake/default_loader.rb
  229 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rake-12.0.0/lib/rake/late_time.rb
  230 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rake-12.0.0/lib/rake/name_space.rb
  231 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rake-12.0.0/lib/rake/backtrace.rb
  232 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/rake-12.0.0/lib/rake.rb
  233 /Users/lucasuyezu/src/github.com/lucasuyezu/ruby_postal/lib/ruby_postal.rb
  234 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/2.3.0/mutex_m.rb
  235 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/minitest-5.10.1/lib/minitest/parallel.rb
  236 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/minitest-5.10.1/lib/minitest/assertions.rb
  237 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/minitest-5.10.1/lib/minitest/unit.rb
  238 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/minitest-5.10.1/lib/minitest/test.rb
  239 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/minitest-5.10.1/lib/minitest.rb
  240 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/minitest-5.10.1/lib/minitest/expectations.rb
  241 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/minitest-5.10.1/lib/minitest/spec.rb
  242 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/minitest-5.10.1/lib/minitest/mock.rb
  243 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/minitest-5.10.1/lib/minitest/autorun.rb
  244 /Users/lucasuyezu/src/github.com/lucasuyezu/ruby_postal/test/test_helper.rb
  245 /Users/lucasuyezu/src/github.com/lucasuyezu/ruby_postal/lib/ruby_postal/cpostal/expand.bundle
  246 /Users/lucasuyezu/src/github.com/lucasuyezu/ruby_postal/lib/ruby_postal/expand.rb
  247 /Users/lucasuyezu/src/github.com/lucasuyezu/ruby_postal/test/ruby_postal_expand_test.rb
  248 /Users/lucasuyezu/src/github.com/lucasuyezu/ruby_postal/lib/ruby_postal/cpostal/parser.bundle
  249 /Users/lucasuyezu/src/github.com/lucasuyezu/ruby_postal/lib/ruby_postal/parser.rb
  250 /Users/lucasuyezu/src/github.com/lucasuyezu/ruby_postal/test/ruby_postal_parser_test.rb
  251 /Users/lucasuyezu/.rbenv/versions/2.3.3/lib/ruby/gems/2.3.0/gems/minitest-5.10.1/lib/minitest/pride_plugin.rb

[NOTE]
You may have encountered a bug in the Ruby interpreter or extension libraries.
Bug reports are welcome.
For details: http://www.ruby-lang.org/bugreport.html

rake aborted!
SignalException: SIGABRT
/Users/lucasuyezu/.rbenv/versions/2.3.3/bin/bundle:22:in `load'
/Users/lucasuyezu/.rbenv/versions/2.3.3/bin/bundle:22:in `<main>'
Tasks: TOP => test
(See full trace by running task with --trace)
```

### Solution
Treat `nil` the same way as an empty string.

Another possible solution would be to check for `nil` or an empty string and return an empty array on the spot, without having to run C code.
