### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ sudo yum install curl autoconf automake libtool pkgconfig
 
 **On Mac OSX**
 ```
-sudo brew install curl autoconf automake libtool pkg-config
+brew install curl autoconf automake libtool pkg-config
 ```
 
 **Installing libpostal**


### PR DESCRIPTION
Homebrew raises exception when running under sudo. Updating README.md to match.
```
Error: Running Homebrew as root is extremely dangerous and no longer supported.
As Homebrew does not drop privileges on installation you would be giving all
build scripts full access to your system.
```